### PR TITLE
YAML Snippet Metadata

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,31 @@
+Schemas:
+  - Name: bin_exp
+    Prefix: cpp
+    Display: Binary Exponentiation with Modulo
+    Description: Effective computation of large exponents module a number.
+
+  - Name: ext_euclid_iter
+    Prefix: cpp
+    Display: Extended Euclidean Algorithm (Iterative)
+    Description: Calculates the GCD of A and B while also determining the coefficients for each.
+
+  - Name: ext_euclid
+    Prefix: cpp
+    Display: Extended Euclidean Algorithm
+    Description: Calculates the GCD of A and B while also determining the coefficients for each.
+
+  - Name: inv_modulo
+    Prefix: cpp
+    Display: Inverse Modulo
+    Description: Returns the modular inverse of a given value using the extended euclidean algorithm.
+    Dependencies: [ext_euclid]
+
+  - Name: sieve_erato
+    Prefix: cpp
+    Display: Sieve of Eratosthenes
+    Description: Find all prime numbers less than or equal to N.
+
+  - Name: template
+    Prefix: cpp
+    Display: C++ Template
+    Description: A general C++ solution template.

--- a/config.yaml
+++ b/config.yaml
@@ -1,31 +1,30 @@
-Schemas:
-  - Name: bin_exp
-    Prefix: cpp
-    Display: Binary Exponentiation with Modulo
-    Description: Effective computation of large exponents module a number.
+- Name: bin_exp
+  Prefix: cpp
+  Display: Binary Exponentiation with Modulo
+  Description: Effective computation of large exponents module a number.
 
-  - Name: ext_euclid_iter
-    Prefix: cpp
-    Display: Extended Euclidean Algorithm (Iterative)
-    Description: Calculates the GCD of A and B while also determining the coefficients for each.
+- Name: ext_euclid_iter
+  Prefix: cpp
+  Display: Extended Euclidean Algorithm (Iterative)
+  Description: Calculates the GCD of A and B while also determining the coefficients for each.
 
-  - Name: ext_euclid
-    Prefix: cpp
-    Display: Extended Euclidean Algorithm
-    Description: Calculates the GCD of A and B while also determining the coefficients for each.
+- Name: ext_euclid
+  Prefix: cpp
+  Display: Extended Euclidean Algorithm
+  Description: Calculates the GCD of A and B while also determining the coefficients for each.
 
-  - Name: inv_modulo
-    Prefix: cpp
-    Display: Inverse Modulo
-    Description: Returns the modular inverse of a given value using the extended euclidean algorithm.
-    Dependencies: [ext_euclid]
+- Name: inv_modulo
+  Prefix: cpp
+  Display: Inverse Modulo
+  Description: Returns the modular inverse of a given value using the extended euclidean algorithm.
+  Dependencies: [ext_euclid]
 
-  - Name: sieve_erato
-    Prefix: cpp
-    Display: Sieve of Eratosthenes
-    Description: Find all prime numbers less than or equal to N.
+- Name: sieve_erato
+  Prefix: cpp
+  Display: Sieve of Eratosthenes
+  Description: Find all prime numbers less than or equal to N.
 
-  - Name: template
-    Prefix: cpp
-    Display: C++ Template
-    Description: A general C++ solution template.
+- Name: template
+  Prefix: cpp
+  Display: C++ Template
+  Description: A general C++ solution template.

--- a/generate.py
+++ b/generate.py
@@ -23,8 +23,8 @@ def get_files_in_dir(directory) :
   filedata = {}
 
   for filename in filenames :
-    f = open(join(directory, filename), "r")
-    filedata[filename] = f.read()
+    with open(join(directory, filename), "r") as f:
+      filedata[filename] = f.read()
 
   return filedata
 

--- a/generate.py
+++ b/generate.py
@@ -30,9 +30,7 @@ def parse_config(filename):
     config = yaml.safe_load(stream)
 
   schemas = {}
-
-  if 'Schemas' not in config: fail("Configuration file is missing top-level key 'Schemas'.")
-  for schema in config['Schemas']:
+  for schema in config:
     if 'Name' not in schema: fail("Schema '%s' does not specify a template name.", schema)
     template_name = schema.get('Name')
     template_disp = schema.get('Display', template_name)
@@ -52,7 +50,7 @@ def parse_config(filename):
     valid_dependencies = []
     for dependency_name in schema['dependencies']:
       if dependency_name in schemas.keys(): valid_dependencies.append(dependency_name)
-      else: warn("Schema '%s' depends on a template that could not be found: '%s'", name, dependency_name)
+      else: warn("Schema '%s' depends on a template that could not be found: '%s'.", template_name, dependency_name)
     schema['dependencies'] = valid_dependencies
   return schemas
 

--- a/generate.py
+++ b/generate.py
@@ -9,7 +9,7 @@ from os import listdir
 from os.path import isfile, join, isdir
 
 def warn(msg, *args) :
-  print(msg % args, sys.stderr)
+  print(msg % args, file=sys.stderr)
 
 def fail(msg, *args) :
   warn(msg, *args)


### PR DESCRIPTION
I mentioned previously that it might be worth replacing the XML schemas with a Doxygen-style header at the top of each template file.  Unfortunately, this is not a very clean solution from the parsing perspective.  As an alternative, I propose using a single YAML configuration file to specify the VS Code snippet metadata.  This takes care of the XML boilerplate and centralizes the location of the metadata to a single file.  The pull request also introduces command-line arguments to replace the global variables and fixes a few small bugs along the way.

With respect to testing, I verified that the output file generated using the configuration file is the same as the one generated using the XML schemas.