### PR TITLE
Output Stream Overloads and Union-Find Templates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,11 @@
   Description: Returns the modular inverse of a given value using the extended euclidean algorithm.
   Dependencies: [ext_euclid]
 
+- Name: ostream_overloads
+  Prefix: cpp
+  Display: Output Stream Overloads
+  Description: Set of output stream overloads for common STL containers.
+
 - Name: sieve_erato
   Prefix: cpp
   Display: Sieve of Eratosthenes

--- a/config.yaml
+++ b/config.yaml
@@ -38,3 +38,8 @@
   Prefix: cpp
   Display: C++ Template
   Description: A general C++ solution template.
+
+- Name: union_find
+  Prefix: cpp
+  Display: Union-Find
+  Description: Union-find implementation with path compression.

--- a/generate.py
+++ b/generate.py
@@ -73,9 +73,9 @@ def resolve_dependencies(schemas, schema) :
 
 
 if __name__ == "__main__" :
-  parser = argparse.ArgumentParser()
+  parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   parser.add_argument('--templates_dir', '-td', type=str, default='templates', help='path to the templates directory')
-  parser.add_argument('--config_file', '-cf', type=str, default='config.yaml', help='path to the configuration file (this overrides schemas_dir)')
+  parser.add_argument('--config_file', '-cf', type=str, default='config.yaml', help='path to the YAML configuration file')
   parser.add_argument('--output_dir', '-od', type=str, default='/mnt/c/Users/Daniel/AppData/Roaming/Code/User/snippets', help='path to the output directory')
   parser.add_argument('--output_filename', '-of', type=str, default='cp.code-snippets', help='name of the output snippets file')
   args = parser.parse_args()

--- a/templates/ostream_overloads
+++ b/templates/ostream_overloads
@@ -1,0 +1,116 @@
+// Output stream overloads.
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
+  if (v.size() == 0) {
+    return out << "[]";
+  }
+
+  out << '[' << v[0];
+  for (int i = 1; i < v.size(); ++i) {
+    out << ' ' << v[i];
+  }
+  return out << ']';
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::vector<std::vector<T>>& m) {
+  if (m.size() == 0) {
+    return out << "[]";
+  }
+
+  for (const auto& row : m) {
+    out << row << endl;
+  }
+  return out;
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::deque<T>& d) {
+  if (d.size() == 0) {
+    return out << "[]";
+  }
+
+  out << '[' << d[0];
+  for (int i = 1; i < d.size(); ++i) {
+    out << ' ' << d[i];
+  }
+  return out << ']';
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::set<T>& s) {
+  if (s.size() == 0) {
+    return out << "{}";
+  }
+
+  out << '{' << *s.begin();
+  for (auto it = ++s.begin(); it != s.end(); ++it) {
+    out << ' ' << *it;
+  }
+  return out << '}';
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::unordered_set<T>& s) {
+  if (s.size() == 0) {
+    return out << "{}";
+  }
+
+  std::vector<T> v(s.begin(), s.end());
+  sort(v.begin(), v.end());
+
+  out << '{' << v[0];
+  for (int i = 1; i < v.size(); ++i) {
+    out << ' ' << v[i];
+  }
+  return out << '}';
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::multiset<T>& s) {
+  return out << std::vector<T>(s.begin(), s.end());
+}
+
+template <typename K, typename V>
+std::ostream& operator<<(std::ostream& out, const std::map<K, V>& m) {
+  if (m.size() == 0) {
+    return out << "{}";
+  }
+
+  std::vector<K> keys;
+  for (const auto& p : m) {
+    keys.push_back(p.first);
+  }
+
+  out << "{" << keys[0] << ": " << m.at(keys[0]);
+  for (int i = 1; i < keys.size(); ++i) {
+    const auto& key = keys[i];
+    out << ", " << key << ": " << m.at(key);
+  }
+  return out << '}';
+}
+
+template <typename K, typename V>
+std::ostream& operator<<(std::ostream& out, const std::unordered_map<K, V>& m) {
+  if (m.size() == 0) {
+    return out << "{}";
+  }
+
+  std::vector<K> keys;
+  for (const auto& p : m) {
+    keys.push_back(p.first);
+  }
+  sort(keys.begin(), keys.end());
+
+  out << "{" << keys[0] << ": " << m.at(keys[0]);
+  for (int i = 1; i < keys.size(); ++i) {
+    const auto& key = keys[i];
+    out << ", " << key << ": " << m.at(key);
+  }
+  return out << '}';
+}
+
+template <typename F, typename S>
+std::ostream& operator<<(std::ostream& out, const std::pair<F, S>& p) {
+  return out << '(' << p.first << ", " << p.second << ')';
+}

--- a/templates/ostream_overloads
+++ b/templates/ostream_overloads
@@ -1,3 +1,11 @@
+#include <deque>
+#include <iostream>
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 // Output stream overloads.
 template <typename T>
 std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {

--- a/templates/ostream_overloads
+++ b/templates/ostream_overloads
@@ -1,11 +1,3 @@
-#include <deque>
-#include <iostream>
-#include <map>
-#include <set>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
-
 // Output stream overloads.
 template <typename T>
 std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {

--- a/templates/union_find
+++ b/templates/union_find
@@ -1,6 +1,3 @@
-#include <algorithm>
-#include <numeric>
-
 struct UnionFind {
   /**
    * The parent site of each site.

--- a/templates/union_find
+++ b/templates/union_find
@@ -1,0 +1,114 @@
+#include <algorithm>
+#include <numeric>
+
+struct UnionFind {
+  /**
+   * The parent site of each site.
+   */
+  int* id;
+
+  /**
+   * The size of the component rooted at each site.
+   */
+  int* sz;
+
+  /**
+   * The total number of sites.
+   */
+  int sites;
+
+  /**
+   * The number of active components.
+   */
+  int comps;
+
+  /**
+   * Constructs a union-find instance with the given capacity.
+   * 
+   * @param capacity The initial number of contiguous components.
+   */
+  UnionFind(const int capacity) : sites(capacity), comps(capacity) {
+    id = new int[capacity];
+    sz = new int[capacity];
+    std::iota(id, id + capacity, 0);
+    std::fill(sz, sz + capacity, 1);
+  }
+
+  /**
+   * Destructs the UnionFind instance.
+   */
+  ~UnionFind() {
+    delete[] id;
+    delete[] sz;
+  }
+
+  /**
+   * Connects two sites in the UnionFind instance.  The ordering of these sites
+   * does not matter.
+   * 
+   * @param site1 The first site.
+   * @param site2 The second site.
+   */
+  void merge(const int site1, const int site2) {
+    int root1 = find(site1);
+    int root2 = find(site2);
+    if (root1 == root2) return;
+
+    if (sz[root1] < sz[root2]) {
+      id[root1] = root2;
+      sz[root2] += sz[root1];
+    } else {
+      id[root2] = root1;
+      sz[root1] += sz[root2];
+    }
+    --comps;
+  }
+
+  /**
+   * Returns the component identifier for the given site.
+   * 
+   * @param site The site.
+   * 
+   * @return The component identifier of the site.
+   */
+  int find(const int site) {
+    int root = site == id[site] ? site : find(id[site]);
+    id[site] = root;
+    return root;
+  }
+
+  /**
+   * Returns the component identifier for the given site.
+   * 
+   * @param site The site.
+   * 
+   * @return The component identifier of the site.
+   */
+  int find(const int site) const {
+    return site == id[site] ? site : find(id[site]);
+  }
+
+  /**
+   * Returns true if the two sites belong to the same component.
+   * 
+   * @param site1 The first site.
+   * @param site2 The second site.
+   * 
+   * @return True if the two sites belong to the same component.
+   */
+  bool connected(const int site1, const int site2) {
+    return find(site1) == find(site2);
+  }
+
+  /**
+   * Returns true if the two sites belong to the same component.
+   * 
+   * @param site1 The first site.
+   * @param site2 The second site.
+   * 
+   * @return True if the two sites belong to the same component.
+   */
+  bool connected(const int site1, const int site2) const {
+    return find(site1) == find(site2);
+  }
+};

--- a/templates/union_find
+++ b/templates/union_find
@@ -43,8 +43,7 @@ struct UnionFind {
   }
 
   /**
-   * Connects two sites in the UnionFind instance.  The ordering of these sites
-   * does not matter.
+   * Connects two sites.  The ordering of these sites does not matter.
    * 
    * @param site1 The first site.
    * @param site2 The second site.


### PR DESCRIPTION
Added a pair of templates which implement `operator<<` overloads for common STL containers and a `UnionFind` structure, respectively.